### PR TITLE
fix: prevent panic on NaN values in panel position sort

### DIFF
--- a/src/state/workspace.rs
+++ b/src/state/workspace.rs
@@ -168,9 +168,9 @@ impl Workspace {
         y_edges.push(bbox_min_y);
 
         // Deduplicate (within 1px tolerance)
-        x_edges.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        x_edges.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         x_edges.dedup_by(|a, b| (*a - *b).abs() < 1.0);
-        y_edges.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        y_edges.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         y_edges.dedup_by(|a, b| (*a - *b).abs() < 1.0);
 
         // Test every (x, y) candidate and score it


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` with `.unwrap_or(std::cmp::Ordering::Equal)` in f32 sort comparisons (`src/state/workspace.rs:171,173`)
- `partial_cmp()` on f32 returns `None` for NaN values — `.unwrap()` would panic

## Test plan
- [ ] `cargo check` passes
- [ ] Create 3+ terminals, drag/resize rapidly — no panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)