### PR TITLE
chore: remove dead code, unused deps, and stub placeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,17 +1103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,15 +1173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1665,35 +1645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,26 +1787,6 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-
-[[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
 
 [[package]]
 name = "lazy_static"
@@ -2004,18 +1935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "miow"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,34 +2047,6 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
-name = "notify"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
-dependencies = [
- "bitflags 2.11.0",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types",
- "walkdir",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "notify-types"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
-dependencies = [
- "instant",
-]
 
 [[package]]
 name = "num-traits"
@@ -3650,7 +3541,6 @@ dependencies = [
  "image",
  "log",
  "minreq",
- "notify",
  "portable-pty",
  "rfd",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ env_logger = "0.11"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "5"
-notify = "7"
 arboard = "3"
 rfd = "0.15"
 minreq = { version = "2", features = ["https-native"] }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -1,1 +1,0 @@
-// TODO: Phase 4 - Default config values

--- a/src/config/hot_reload.rs
+++ b/src/config/hot_reload.rs
@@ -1,1 +1,0 @@
-// TODO: Phase 4 - File watcher for live config reload

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,0 @@
-// Config loading + validation
-
-pub mod defaults;
-pub mod hot_reload;
-pub mod schema;

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1,1 +1,0 @@
-// TODO: Phase 4 - Config structs (serde + TOML deserialization)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 mod app;
 mod canvas;
 mod command_palette;
-mod config;
 mod panel;
 mod shortcuts;
 mod sidebar;

--- a/src/state/workspace.rs
+++ b/src/state/workspace.rs
@@ -9,7 +9,6 @@ use crate::panel::CanvasPanel;
 use crate::terminal::panel::TerminalPanel;
 
 pub struct Workspace {
-    #[allow(dead_code)]
     pub id: Uuid,
     pub name: String,
     pub cwd: Option<PathBuf>,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -5,4 +5,3 @@ pub mod input;
 pub mod panel;
 pub mod pty;
 pub mod renderer;
-pub mod selection;

--- a/src/terminal/panel.rs
+++ b/src/terminal/panel.rs
@@ -220,32 +220,7 @@ impl TerminalPanel {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn new(title: impl Into<String>, position: Pos2, size: Vec2, color: Color32) -> Self {
-        Self {
-            id: Uuid::new_v4(),
-            title: title.into(),
-            position,
-            size,
-            color,
-            z_index: 0,
-            focused: false,
-            pty: None,
-            last_cols: 80,
-            last_rows: 24,
-            spawn_error: None,
-            selection: None,
-            selection_display_offset: 0,
-            selecting: false,
-            scroll_remainder: 0.0,
-            scrollbar_grab_offset: None,
-            last_click_time: 0.0,
-            click_count: 0,
-            drag_virtual_pos: None,
-            resize_virtual_rect: None,
-            bell_flash_until: 0.0,
-        }
-    }
+
 
     /// Create a panel from saved state, spawning a new terminal process.
     pub fn from_saved(

--- a/src/terminal/renderer.rs
+++ b/src/terminal/renderer.rs
@@ -18,7 +18,6 @@ const CELL_HEIGHT_ESTIMATE: f32 = FONT_SIZE * 1.25;
 const CURSOR_BLINK_ON_SECONDS: f64 = 0.6;
 const CURSOR_BLINK_OFF_SECONDS: f64 = 0.4;
 
-#[allow(dead_code)]
 pub fn cell_size(ctx: &egui::Context) -> (f32, f32) {
     measure_cell(ctx)
 }

--- a/src/terminal/selection.rs
+++ b/src/terminal/selection.rs
@@ -1,1 +1,0 @@
-// TODO: Phase 7 - Text selection handling (click, drag, word, line)

--- a/src/utils/id.rs
+++ b/src/utils/id.rs
@@ -1,7 +1,0 @@
-use uuid::Uuid;
-
-/// Generate a new unique panel/workspace ID.
-#[allow(dead_code)]
-pub fn new_id() -> Uuid {
-    Uuid::new_v4()
-}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,3 @@
 // Shared utilities
 
-pub mod id;
 pub mod platform;


### PR DESCRIPTION
## Summary
- Remove unused `notify` dependency from Cargo.toml
- Delete stub `src/config/` module (4 files, all single-line TODOs)
- Delete stub `src/terminal/selection.rs` (selection is implemented in panel.rs)
- Delete dead `src/utils/id.rs` (never called)
- Remove dead `TerminalPanel::new()` constructor
- Fix incorrect `#[allow(dead_code)]` on `cell_size()` and `Workspace.id` (both are used)

14 files changed, -158 lines

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo test --locked` passes
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)