### PR TITLE
perf: throttle PTY repaint requests to ~60fps

### DIFF
--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -129,6 +129,7 @@ impl PtyHandle {
         let ctx_clone_wait = ctx.clone();
 
         let event_thread = thread::spawn(move || {
+            let mut last_repaint = Instant::now();
             while let Ok(event) = event_rx.recv() {
                 match event {
                     Event::PtyWrite(text) => {
@@ -167,7 +168,11 @@ impl PtyHandle {
                     | Event::TextAreaSizeRequest(_) => {}
                 }
 
-                ctx_clone_events.request_repaint();
+                // Throttle repaints to ~60fps to avoid excessive redraws during heavy output
+                if last_repaint.elapsed() >= Duration::from_millis(16) {
+                    ctx_clone_events.request_repaint();
+                    last_repaint = Instant::now();
+                }
                 if !alive_clone_events.load(Ordering::Relaxed) {
                     thread::sleep(Duration::from_millis(10));
                 }
@@ -177,6 +182,7 @@ impl PtyHandle {
         let reader_thread = thread::spawn(move || {
             let mut processor: Processor = Processor::new();
             let mut buf = [0u8; 4096];
+            let mut last_repaint = Instant::now();
 
             loop {
                 match reader.read(&mut buf) {
@@ -193,7 +199,11 @@ impl PtyHandle {
                             *last_output = Instant::now();
                         }
 
-                        ctx_clone.request_repaint();
+                        // Throttle repaints to ~60fps to avoid excessive redraws during heavy output
+                        if last_repaint.elapsed() >= Duration::from_millis(16) {
+                            ctx_clone.request_repaint();
+                            last_repaint = Instant::now();
+                        }
                     }
                     Err(e) => {
                         log::debug!("PTY read error: {e}");
@@ -203,6 +213,7 @@ impl PtyHandle {
             }
 
             alive_clone.store(false, Ordering::Relaxed);
+            // Always request a final repaint to ensure the last frame is rendered
             ctx_clone.request_repaint();
         });
 


### PR DESCRIPTION
## Summary
- Add 16ms time-based throttle to `request_repaint()` in both event and reader threads
- Previously called on every terminal event/chunk, causing excessive CPU during heavy output
- Final repaint after reader loop exit ensures last frame always renders

## Test plan
- [ ] Run `seq 1 100000` — should feel smoother, less CPU usage
- [ ] Normal typing/scrolling still responsive
- [ ] Terminal exit reflected promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)