### PR TITLE
feat: handle OSC 52 clipboard load and log unhandled terminal events

### DIFF
--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -159,11 +159,24 @@ impl PtyHandle {
                             let _ = clipboard.set_text(data);
                         }
                     }
+                    Event::ClipboardLoad(_clipboard_type, formatter) => {
+                        // OSC 52 query: program wants to read clipboard contents
+                        if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                            if let Ok(text) = clipboard.get_text() {
+                                let response = formatter(&text);
+                                if let Ok(mut w) = writer_clone.lock() {
+                                    let _ = w.write_all(response.as_bytes());
+                                    let _ = w.flush();
+                                }
+                            }
+                        }
+                    }
+                    Event::ColorRequest(index, _) => {
+                        log::debug!("Unhandled ColorRequest for index {}", index);
+                    }
                     Event::Wakeup
                     | Event::MouseCursorDirty
                     | Event::CursorBlinkingChange
-                    | Event::ClipboardLoad(_, _)
-                    | Event::ColorRequest(_, _)
                     | Event::TextAreaSizeRequest(_) => {}
                 }
 


### PR DESCRIPTION
## Summary
- Handle `ClipboardLoad` events — programs can now read clipboard via OSC 52 query
- Add `log::debug!` for `ColorRequest` events (previously silently dropped)
- No new dependencies — uses alacritty_terminal's built-in formatter

## Test plan
- [ ] In vim, yank text — clipboard should work bidirectionally
- [ ] `cargo test --locked` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)