### PR TITLE
feat: middle-click close panel, auto-hide chrome in fullscreen

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -429,8 +429,9 @@ impl eframe::App for VoidApp {
             }
         }
 
-        // --- Sidebar ---
-        if self.sidebar_visible {
+        // --- Sidebar (hidden in fullscreen) ---
+        let is_fullscreen = ctx.input(|i| i.viewport().fullscreen.unwrap_or(false));
+        if self.sidebar_visible && !is_fullscreen {
             egui::SidePanel::left("sidebar")
                 .exact_width(SIDEBAR_WIDTH)
                 .frame(
@@ -800,7 +801,7 @@ impl eframe::App for VoidApp {
         // --- Minimap overlay ---
         // Drawn in a small foreground area covering only the minimap rect,
         // so it doesn't block terminal interactions.
-        if self.show_minimap {
+        if self.show_minimap && !is_fullscreen {
             let mm_w = 220.0;
             let mm_h = 170.0;
             let mm_pos = Pos2::new(canvas_rect.max.x - mm_w, canvas_rect.max.y - mm_h);

--- a/src/terminal/panel.rs
+++ b/src/terminal/panel.rs
@@ -1203,6 +1203,10 @@ impl TerminalPanel {
         if title_resp.clicked_by(egui::PointerButton::Primary) {
             ix.clicked = true;
         }
+        // Middle-click on title bar to close panel
+        if title_resp.clicked_by(egui::PointerButton::Middle) {
+            ix.action = Some(PanelAction::Close);
+        }
         if title_resp.dragged_by(egui::PointerButton::Primary) {
             ix.dragging_title = true;
             ix.drag_delta = title_resp.drag_delta();


### PR DESCRIPTION
## Summary
- Middle-click on title bar closes the panel (like browser tabs)
- Sidebar and minimap auto-hide in fullscreen mode (F11) for maximum terminal space

## Test plan
- [ ] Middle-click a terminal title bar → panel closes
- [ ] Press F11 → sidebar and minimap disappear
- [ ] Press F11 again → sidebar and minimap come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)