### PR TITLE
feat: dynamic font size controls (Ctrl+Shift+Plus/Minus)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ pub struct VoidApp {
     sidebar_visible: bool,
     show_grid: bool,
     show_minimap: bool,
+    font_size: f32,
     ctx: Option<egui::Context>,
     command_palette: CommandPalette,
     renaming_panel: Option<uuid::Uuid>,
@@ -56,12 +57,13 @@ impl VoidApp {
         };
 
         // Try to restore saved layout, otherwise create a default workspace
-        let (workspaces, active_ws, sidebar_visible, show_grid, show_minimap, viewport) =
+        let (workspaces, active_ws, sidebar_visible, show_grid, show_minimap, viewport, font_size) =
             if let Some(saved) = crate::state::persistence::load_state() {
+                let fs = saved.font_size;
                 let wss: Vec<Workspace> = saved
                     .workspaces
                     .iter()
-                    .map(|ws_state| Workspace::from_saved(&ctx, ws_state, PANEL_COLORS))
+                    .map(|ws_state| Workspace::from_saved(&ctx, ws_state, PANEL_COLORS, fs))
                     .collect();
                 let active = saved.active_ws.min(wss.len().saturating_sub(1));
                 let vp = Viewport {
@@ -75,10 +77,12 @@ impl VoidApp {
                     saved.show_grid,
                     saved.show_minimap,
                     vp,
+                    fs,
                 )
             } else {
+                let fs = crate::terminal::renderer::DEFAULT_FONT_SIZE;
                 let mut ws = Workspace::new("Default", None);
-                ws.spawn_terminal(&ctx, PANEL_COLORS);
+                ws.spawn_terminal(&ctx, PANEL_COLORS, fs);
                 (
                     vec![ws],
                     0,
@@ -89,6 +93,7 @@ impl VoidApp {
                         pan: Vec2::new(100.0, 50.0),
                         zoom: 0.75,
                     },
+                    fs,
                 )
             };
 
@@ -99,6 +104,7 @@ impl VoidApp {
             sidebar_visible,
             show_grid,
             show_minimap,
+            font_size,
             ctx: Some(ctx),
             command_palette: CommandPalette::default(),
             renaming_panel: None,
@@ -190,7 +196,7 @@ impl VoidApp {
 
             let mut ws = Workspace::new(name, Some(path));
             if let Some(ctx) = &self.ctx {
-                ws.spawn_terminal(ctx, PANEL_COLORS);
+                ws.spawn_terminal(ctx, PANEL_COLORS, self.font_size);
             }
 
             self.workspaces.push(ws);
@@ -201,7 +207,8 @@ impl VoidApp {
 
     fn spawn_terminal(&mut self) {
         if let Some(ctx) = self.ctx.clone() {
-            self.ws_mut().spawn_terminal(&ctx, PANEL_COLORS);
+            let font_size = self.font_size;
+            self.ws_mut().spawn_terminal(&ctx, PANEL_COLORS, font_size);
         }
     }
 
@@ -231,6 +238,17 @@ impl VoidApp {
                 self.viewport.pan = Vec2::ZERO;
             }
             Command::ZoomToFit => self.zoom_to_fit(screen_rect),
+            Command::FontZoomIn => {
+                use crate::terminal::renderer::{FONT_SIZE_STEP, MAX_FONT_SIZE};
+                self.font_size = (self.font_size + FONT_SIZE_STEP).min(MAX_FONT_SIZE);
+            }
+            Command::FontZoomOut => {
+                use crate::terminal::renderer::{FONT_SIZE_STEP, MIN_FONT_SIZE};
+                self.font_size = (self.font_size - FONT_SIZE_STEP).max(MIN_FONT_SIZE);
+            }
+            Command::FontZoomReset => {
+                self.font_size = crate::terminal::renderer::DEFAULT_FONT_SIZE;
+            }
             Command::FocusNext => self.ws_mut().focus_next(),
             Command::FocusPrev => self.ws_mut().focus_prev(),
             Command::ToggleFullscreen => {
@@ -296,6 +314,13 @@ impl VoidApp {
                 cmd = Some(Command::FocusPrev);
             } else if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::Num0) {
                 cmd = Some(Command::ZoomToFit);
+            } else if i.modifiers.ctrl
+                && i.modifiers.shift
+                && (i.key_pressed(egui::Key::Equals) || i.key_pressed(egui::Key::Plus))
+            {
+                cmd = Some(Command::FontZoomIn);
+            } else if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::Minus) {
+                cmd = Some(Command::FontZoomOut);
             } else if i.key_pressed(egui::Key::F2) && !i.modifiers.ctrl {
                 cmd = Some(Command::RenameTerminal);
             }
@@ -326,6 +351,7 @@ impl VoidApp {
             sidebar_visible: self.sidebar_visible,
             show_grid: self.show_grid,
             show_minimap: self.show_minimap,
+            font_size: self.font_size,
         }
     }
 }
@@ -541,7 +567,8 @@ impl eframe::App for VoidApp {
             if let Some(idx) = hovered_terminal {
                 let scroll_y = ctx.input(|input| input.smooth_scroll_delta.y);
                 if scroll_y != 0.0 {
-                    self.ws_mut().panels[idx].handle_scroll(ctx, scroll_y);
+                    let font_size = self.font_size;
+                    self.ws_mut().panels[idx].handle_scroll(ctx, scroll_y, font_size);
                     ctx.input_mut(|input| {
                         input.smooth_scroll_delta = egui::Vec2::ZERO;
                         input.raw_scroll_delta = egui::Vec2::ZERO;
@@ -628,7 +655,8 @@ impl eframe::App for VoidApp {
                     {
                         continue;
                     }
-                    let ix = self.ws_mut().panels[idx].show(ui, transform, canvas_rect);
+                    let font_size = self.font_size;
+                    let ix = self.ws_mut().panels[idx].show(ui, transform, canvas_rect, font_size);
                     if ix.clicked || ix.dragging_title || ix.resizing || ix.action.is_some() {
                         interactions.push((idx, ix));
                     }

--- a/src/canvas/scene.rs
+++ b/src/canvas/scene.rs
@@ -42,8 +42,8 @@ pub fn handle_canvas_input(
             }
         }
 
-        // --- Zoom: keyboard Ctrl+= / Ctrl+- / Ctrl+0 ---
-        if input.modifiers.ctrl {
+        // --- Zoom: keyboard Ctrl+= / Ctrl+- / Ctrl+0 (without Shift — Shift variants are font zoom) ---
+        if input.modifiers.ctrl && !input.modifiers.shift {
             if input.key_pressed(egui::Key::Equals) || input.key_pressed(egui::Key::Plus) {
                 let center = screen_rect.center();
                 viewport.zoom_around(center, screen_rect, ZOOM_KEYBOARD_FACTOR);

--- a/src/command_palette/commands.rs
+++ b/src/command_palette/commands.rs
@@ -13,6 +13,9 @@ pub enum Command {
     ZoomOut,
     ZoomReset,
     ZoomToFit,
+    FontZoomIn,
+    FontZoomOut,
+    FontZoomReset,
     FocusNext,
     FocusPrev,
     ToggleFullscreen,
@@ -86,6 +89,21 @@ pub const COMMANDS: &[CommandEntry] = &[
         command: Command::ZoomReset,
         label: "Reset Zoom",
         shortcut: "Ctrl+0",
+    },
+    CommandEntry {
+        command: Command::FontZoomIn,
+        label: "Increase Font Size",
+        shortcut: "Ctrl+Shift+=",
+    },
+    CommandEntry {
+        command: Command::FontZoomOut,
+        label: "Decrease Font Size",
+        shortcut: "Ctrl+Shift+-",
+    },
+    CommandEntry {
+        command: Command::FontZoomReset,
+        label: "Reset Font Size",
+        shortcut: "",
     },
     CommandEntry {
         command: Command::ToggleFullscreen,

--- a/src/panel.rs
+++ b/src/panel.rs
@@ -130,9 +130,10 @@ impl CanvasPanel {
         ui: &mut egui::Ui,
         transform: egui::emath::TSTransform,
         screen_clip: Rect,
+        font_size: f32,
     ) -> PanelInteraction {
         match self {
-            Self::Terminal(t) => t.show(ui, transform, screen_clip),
+            Self::Terminal(t) => t.show(ui, transform, screen_clip, font_size),
         }
     }
 
@@ -148,9 +149,9 @@ impl CanvasPanel {
         }
     }
 
-    pub fn handle_scroll(&mut self, ctx: &egui::Context, scroll_y: f32) {
+    pub fn handle_scroll(&mut self, ctx: &egui::Context, scroll_y: f32, font_size: f32) {
         match self {
-            Self::Terminal(t) => t.handle_scroll(ctx, scroll_y),
+            Self::Terminal(t) => t.handle_scroll(ctx, scroll_y, font_size),
         }
     }
 

--- a/src/state/persistence.rs
+++ b/src/state/persistence.rs
@@ -11,6 +11,12 @@ pub struct AppState {
     pub sidebar_visible: bool,
     pub show_grid: bool,
     pub show_minimap: bool,
+    #[serde(default = "default_font_size")]
+    pub font_size: f32,
+}
+
+fn default_font_size() -> f32 {
+    crate::terminal::renderer::DEFAULT_FONT_SIZE
 }
 
 /// Serializable snapshot of a single workspace.

--- a/src/state/workspace.rs
+++ b/src/state/workspace.rs
@@ -40,6 +40,7 @@ impl Workspace {
         ctx: &egui::Context,
         state: &crate::state::persistence::WorkspaceState,
         colors: &[egui::Color32],
+        font_size: f32,
     ) -> Self {
         let cwd = state.cwd.clone();
         let mut ws = Self {
@@ -54,13 +55,13 @@ impl Workspace {
         };
 
         for panel_state in &state.panels {
-            let panel = TerminalPanel::from_saved(ctx, panel_state, cwd.as_deref());
+            let panel = TerminalPanel::from_saved(ctx, panel_state, cwd.as_deref(), font_size);
             ws.panels.push(CanvasPanel::Terminal(panel));
         }
 
         // If no panels were restored, spawn a default one
         if ws.panels.is_empty() {
-            ws.spawn_terminal(ctx, colors);
+            ws.spawn_terminal(ctx, colors, font_size);
         }
 
         ws
@@ -89,7 +90,12 @@ impl Workspace {
         self.next_z += 1;
     }
 
-    pub fn spawn_terminal(&mut self, ctx: &egui::Context, colors: &[egui::Color32]) {
+    pub fn spawn_terminal(
+        &mut self,
+        ctx: &egui::Context,
+        colors: &[egui::Color32],
+        font_size: f32,
+    ) {
         let color = colors[self.next_color % colors.len()];
         self.next_color += 1;
 
@@ -101,8 +107,14 @@ impl Workspace {
             p.set_focused(false);
         }
 
-        let mut panel =
-            TerminalPanel::new_with_terminal(ctx, position, new_size, color, self.cwd.as_deref());
+        let mut panel = TerminalPanel::new_with_terminal(
+            ctx,
+            position,
+            new_size,
+            color,
+            self.cwd.as_deref(),
+            font_size,
+        );
         panel.z_index = self.next_z;
         panel.focused = true;
         self.next_z += 1;

--- a/src/terminal/panel.rs
+++ b/src/terminal/panel.rs
@@ -67,6 +67,37 @@ pub const VOID_SHORTCUTS: &[(Modifiers, Key)] = &[
         },
         Key::T,
     ),
+    // Font zoom: Ctrl+Shift+= / Ctrl+Shift+-
+    (
+        Modifiers {
+            alt: false,
+            ctrl: true,
+            shift: true,
+            mac_cmd: false,
+            command: false,
+        },
+        Key::Equals,
+    ),
+    (
+        Modifiers {
+            alt: false,
+            ctrl: true,
+            shift: true,
+            mac_cmd: false,
+            command: false,
+        },
+        Key::Plus,
+    ),
+    (
+        Modifiers {
+            alt: false,
+            ctrl: true,
+            shift: true,
+            mac_cmd: false,
+            command: false,
+        },
+        Key::Minus,
+    ),
 ];
 
 pub struct TerminalPanel {
@@ -182,10 +213,11 @@ impl TerminalPanel {
         size: Vec2,
         color: Color32,
         cwd: Option<&std::path::Path>,
+        font_size: f32,
     ) -> Self {
         let content_size = Self::terminal_content_size(size);
         let (cols, rows) =
-            crate::terminal::renderer::compute_grid_size(content_size.x, content_size.y);
+            crate::terminal::renderer::compute_grid_size(content_size.x, content_size.y, font_size);
         let mut title = cwd
             .and_then(|p| p.file_name())
             .map(|n| n.to_string_lossy().into_owned())
@@ -258,12 +290,13 @@ impl TerminalPanel {
         ctx: &egui::Context,
         state: &crate::state::persistence::PanelState,
         cwd: Option<&std::path::Path>,
+        font_size: f32,
     ) -> Self {
         let position = Pos2::new(state.position[0], state.position[1]);
         let size = Vec2::new(state.size[0], state.size[1]);
         let color = Color32::from_rgb(state.color[0], state.color[1], state.color[2]);
 
-        let mut panel = Self::new_with_terminal(ctx, position, size, color, cwd);
+        let mut panel = Self::new_with_terminal(ctx, position, size, color, cwd, font_size);
         panel.z_index = state.z_index;
         panel.focused = state.focused;
         panel
@@ -340,7 +373,7 @@ impl TerminalPanel {
         Self::terminal_body_rect(self.rect()).contains(canvas_pos)
     }
 
-    pub fn handle_scroll(&mut self, ctx: &egui::Context, scroll_y: f32) {
+    pub fn handle_scroll(&mut self, ctx: &egui::Context, scroll_y: f32, font_size: f32) {
         let Some(pty) = &self.pty else {
             return;
         };
@@ -348,7 +381,7 @@ impl TerminalPanel {
             return;
         }
 
-        let (_, row_height) = crate::terminal::renderer::cell_size(ctx);
+        let (_, row_height) = crate::terminal::renderer::cell_size(ctx, font_size);
         let row_height = row_height.max(1.0);
 
         self.scroll_remainder += scroll_y;
@@ -462,13 +495,14 @@ impl TerminalPanel {
         }
     }
 
-    pub fn check_resize(&mut self, ctx: &egui::Context) {
+    pub fn check_resize(&mut self, ctx: &egui::Context, font_size: f32) {
         if let Some(pty) = &self.pty {
             let content_size = Self::terminal_content_size(self.size);
             let (cols, rows) = crate::terminal::renderer::compute_grid_size_from_ctx(
                 ctx,
                 content_size.x,
                 content_size.y,
+                font_size,
             );
             if cols != self.last_cols || rows != self.last_rows {
                 self.last_cols = cols;
@@ -489,8 +523,14 @@ impl TerminalPanel {
     }
 
     /// Convert pointer position to terminal cell (col, row), clamped to grid bounds.
-    fn pos_to_cell(&self, pos: Pos2, body: Rect, ctx: &egui::Context) -> (usize, usize) {
-        let (cw, ch) = crate::terminal::renderer::cell_size(ctx);
+    fn pos_to_cell(
+        &self,
+        pos: Pos2,
+        body: Rect,
+        ctx: &egui::Context,
+        font_size: f32,
+    ) -> (usize, usize) {
+        let (cw, ch) = crate::terminal::renderer::cell_size(ctx, font_size);
         let col = ((pos.x - body.min.x - crate::terminal::renderer::PAD_X) / cw)
             .floor()
             .clamp(0.0, (self.last_cols as f32) - 1.0) as usize;
@@ -517,8 +557,9 @@ impl TerminalPanel {
         ui: &mut egui::Ui,
         transform: egui::emath::TSTransform,
         screen_clip: Rect,
+        font_size: f32,
     ) -> PanelInteraction {
-        self.check_resize(ui.ctx());
+        self.check_resize(ui.ctx(), font_size);
         let mut ix = PanelInteraction::default();
         let pr = self.rect();
         let painter = ui.painter();
@@ -657,6 +698,7 @@ impl TerminalPanel {
                     transform,
                     screen_clip,
                     self.id,
+                    font_size,
                 );
                 scrollbar_state = Some(ScrollbarState {
                     history_size: term.grid().history_size(),
@@ -769,7 +811,7 @@ impl TerminalPanel {
         // We adjust by the scroll delta so the highlight follows content and scrolls off-screen.
         if local_interactions_enabled {
             if let Some((sc, sr, ec, er)) = self.selection {
-                let (cw, ch) = crate::terminal::renderer::cell_size(ui.ctx());
+                let (cw, ch) = crate::terminal::renderer::cell_size(ui.ctx(), font_size);
                 let pad_x = crate::terminal::renderer::PAD_X;
                 let pad_y = crate::terminal::renderer::PAD_Y;
                 let max_col = self.last_cols as usize;
@@ -1077,7 +1119,7 @@ impl TerminalPanel {
                 2 => {
                     // Double-click: select word
                     if let Some(pos) = body_resp.interact_pointer_pos() {
-                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                         if let Some((start, end)) = self.word_boundaries_at(col, row) {
                             self.selection = Some((start, row, end, row));
                             self.selection_display_offset =
@@ -1088,7 +1130,7 @@ impl TerminalPanel {
                 3 => {
                     // Triple-click: select entire line
                     if let Some(pos) = body_resp.interact_pointer_pos() {
-                        let (_, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                        let (_, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                         let last_col = (self.last_cols as usize).saturating_sub(1);
                         self.selection = Some((0, row, last_col, row));
                         self.selection_display_offset =
@@ -1105,7 +1147,7 @@ impl TerminalPanel {
         if local_interactions_enabled && body_resp.drag_started_by(egui::PointerButton::Primary) {
             ix.clicked = true;
             if let Some(pos) = body_resp.interact_pointer_pos() {
-                let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                 self.selection = Some((col, row, col, row));
                 self.selection_display_offset =
                     scrollbar_state.map(|s| s.display_offset).unwrap_or(0);
@@ -1117,13 +1159,13 @@ impl TerminalPanel {
             && body_resp.dragged_by(egui::PointerButton::Primary)
         {
             if let Some(pos) = body_resp.hover_pos() {
-                let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                 if let Some(ref mut sel) = self.selection {
                     sel.2 = col;
                     sel.3 = row;
                 }
             } else if let Some(pos) = body_resp.interact_pointer_pos() {
-                let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                 if let Some(ref mut sel) = self.selection {
                     sel.2 = col;
                     sel.3 = row;
@@ -1155,7 +1197,7 @@ impl TerminalPanel {
                 {
                     ix.clicked = true;
                     if let Some(pos) = body_resp.interact_pointer_pos() {
-                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                         send_mouse(0, col, row, true);
                     }
                 }
@@ -1163,7 +1205,7 @@ impl TerminalPanel {
                 if body_resp.clicked_by(egui::PointerButton::Middle) {
                     ix.clicked = true;
                     if let Some(pos) = body_resp.interact_pointer_pos() {
-                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                         send_mouse(1, col, row, true);
                         send_mouse(1, col, row, false);
                     }
@@ -1171,7 +1213,7 @@ impl TerminalPanel {
                 // Right click
                 if body_resp.clicked_by(egui::PointerButton::Secondary) {
                     if let Some(pos) = body_resp.interact_pointer_pos() {
-                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                         send_mouse(2, col, row, true);
                         send_mouse(2, col, row, false);
                     }
@@ -1179,14 +1221,14 @@ impl TerminalPanel {
                 // Mouse drag (motion with button held)
                 if body_resp.dragged_by(egui::PointerButton::Primary) {
                     if let Some(pos) = body_resp.hover_pos().or(body_resp.interact_pointer_pos()) {
-                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                         send_mouse(32, col, row, true);
                     }
                 }
                 // Click release
                 if body_resp.drag_stopped() {
                     if let Some(pos) = body_resp.interact_pointer_pos() {
-                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx());
+                        let (col, row) = self.pos_to_cell(pos, content_rect, ui.ctx(), font_size);
                         send_mouse(0, col, row, false);
                     }
                 }

--- a/src/terminal/renderer.rs
+++ b/src/terminal/renderer.rs
@@ -10,20 +10,29 @@ use std::time::Duration;
 use crate::terminal::colors::{self, DEFAULT_BG};
 use crate::terminal::pty::EventProxy;
 
-pub const FONT_SIZE: f32 = 18.0;
+pub const DEFAULT_FONT_SIZE: f32 = 18.0;
+pub const MIN_FONT_SIZE: f32 = 8.0;
+pub const MAX_FONT_SIZE: f32 = 40.0;
+pub const FONT_SIZE_STEP: f32 = 2.0;
 pub const PAD_X: f32 = 10.0;
 pub const PAD_Y: f32 = 6.0;
-const CELL_WIDTH_ESTIMATE: f32 = FONT_SIZE * 0.6;
-const CELL_HEIGHT_ESTIMATE: f32 = FONT_SIZE * 1.25;
 const CURSOR_BLINK_ON_SECONDS: f64 = 0.6;
 const CURSOR_BLINK_OFF_SECONDS: f64 = 0.4;
 
-pub fn cell_size(ctx: &egui::Context) -> (f32, f32) {
-    measure_cell(ctx)
+fn cell_width_estimate(font_size: f32) -> f32 {
+    font_size * 0.6
 }
 
-fn measure_cell(ctx: &egui::Context) -> (f32, f32) {
-    let font = FontId::monospace(FONT_SIZE);
+fn cell_height_estimate(font_size: f32) -> f32 {
+    font_size * 1.25
+}
+
+pub fn cell_size(ctx: &egui::Context, font_size: f32) -> (f32, f32) {
+    measure_cell(ctx, font_size)
+}
+
+fn measure_cell(ctx: &egui::Context, font_size: f32) -> (f32, f32) {
+    let font = FontId::monospace(font_size);
     ctx.fonts(|fonts| {
         let g = fonts.layout_no_wrap("M".to_string(), font, Color32::WHITE);
         (g.rect.width(), g.rect.height())
@@ -41,12 +50,12 @@ fn grid_size_for_cell_metrics(
     (cols, rows)
 }
 
-pub fn compute_grid_size(body_width: f32, body_height: f32) -> (u16, u16) {
+pub fn compute_grid_size(body_width: f32, body_height: f32, font_size: f32) -> (u16, u16) {
     let (cols, rows) = grid_size_for_cell_metrics(
         body_width,
         body_height,
-        CELL_WIDTH_ESTIMATE,
-        CELL_HEIGHT_ESTIMATE,
+        cell_width_estimate(font_size),
+        cell_height_estimate(font_size),
     );
     (cols as u16, rows as u16)
 }
@@ -55,8 +64,9 @@ pub fn compute_grid_size_from_ctx(
     ctx: &egui::Context,
     body_width: f32,
     body_height: f32,
+    font_size: f32,
 ) -> (u16, u16) {
-    let (cw, ch) = measure_cell(ctx);
+    let (cw, ch) = measure_cell(ctx, font_size);
     let (cols, rows) = grid_size_for_cell_metrics(body_width, body_height, cw, ch);
     (cols as u16, rows as u16)
 }
@@ -74,8 +84,9 @@ pub fn render_terminal(
     transform: egui::emath::TSTransform,
     screen_clip: Rect,
     _panel_id: uuid::Uuid,
+    font_size: f32,
 ) {
-    let (cw, ch) = measure_cell(ctx);
+    let (cw, ch) = measure_cell(ctx, font_size);
     if cw < 1.0 || ch < 1.0 {
         return;
     }
@@ -85,7 +96,7 @@ pub fn render_terminal(
         grid_size_for_cell_metrics(body_rect.width(), body_rect.height(), cw, ch);
 
     // --- Screen-space setup ---
-    let screen_font_size = FONT_SIZE * zoom;
+    let screen_font_size = font_size * zoom;
     let screen_font = FontId::monospace(screen_font_size);
     let screen_cw = cw * zoom;
     let screen_ch = ch * zoom;


### PR DESCRIPTION
Font size adjustable via Ctrl+Shift+=/-, persisted in layout.json, range 8-40.