### PR TITLE
feat: save and restore per-terminal CWD across sessions

### DIFF
--- a/src/state/persistence.rs
+++ b/src/state/persistence.rs
@@ -35,6 +35,9 @@ pub struct PanelState {
     pub color: [u8; 3],
     pub z_index: u32,
     pub focused: bool,
+    /// Current working directory of the shell when the panel was saved.
+    #[serde(default)]
+    pub cwd: Option<PathBuf>,
 }
 
 /// Return the path to the state file.

--- a/src/terminal/panel.rs
+++ b/src/terminal/panel.rs
@@ -254,23 +254,27 @@ impl TerminalPanel {
     }
 
     /// Create a panel from saved state, spawning a new terminal process.
+    /// Uses the panel's saved CWD if available, falls back to workspace CWD.
     pub fn from_saved(
         ctx: &egui::Context,
         state: &crate::state::persistence::PanelState,
-        cwd: Option<&std::path::Path>,
+        workspace_cwd: Option<&std::path::Path>,
     ) -> Self {
         let position = Pos2::new(state.position[0], state.position[1]);
         let size = Vec2::new(state.size[0], state.size[1]);
         let color = Color32::from_rgb(state.color[0], state.color[1], state.color[2]);
 
+        // Prefer per-panel CWD (from last session), fall back to workspace CWD
+        let cwd = state.cwd.as_deref().or(workspace_cwd);
         let mut panel = Self::new_with_terminal(ctx, position, size, color, cwd);
         panel.z_index = state.z_index;
         panel.focused = state.focused;
         panel
     }
 
-    /// Snapshot the panel layout for persistence (no PTY state).
+    /// Snapshot the panel layout for persistence (includes CWD if available).
     pub fn to_saved(&self) -> crate::state::persistence::PanelState {
+        let cwd = self.pty.as_ref().and_then(|pty| pty.current_cwd());
         crate::state::persistence::PanelState {
             title: self.title.clone(),
             position: [self.position.x, self.position.y],
@@ -278,6 +282,7 @@ impl TerminalPanel {
             color: [self.color.r(), self.color.g(), self.color.b()],
             z_index: self.z_index,
             focused: self.focused,
+            cwd,
         }
     }
 

--- a/src/terminal/pty.rs
+++ b/src/terminal/pty.rs
@@ -55,6 +55,7 @@ pub struct PtyHandle {
     last_output_at: Arc<Mutex<Instant>>,
     master: Box<dyn portable_pty::MasterPty + Send>,
     killer: Box<dyn ChildKiller + Send + Sync>,
+    child_pid: Option<u32>,
     _event_thread: thread::JoinHandle<()>,
     _reader_thread: thread::JoinHandle<()>,
     _waiter_thread: thread::JoinHandle<()>,
@@ -87,6 +88,7 @@ impl PtyHandle {
         }
 
         let mut child = pair.slave.spawn_command(cmd)?;
+        let child_pid = child.process_id();
         let killer = child.clone_killer();
         drop(pair.slave);
 
@@ -222,6 +224,7 @@ impl PtyHandle {
             last_output_at,
             master: pair.master,
             killer,
+            child_pid,
             _event_thread: event_thread,
             _reader_thread: reader_thread,
             _waiter_thread: waiter_thread,
@@ -270,6 +273,15 @@ impl PtyHandle {
             .unwrap_or(Duration::from_secs(999))
     }
 
+    /// Get the current working directory of the child process.
+    pub fn current_cwd(&self) -> Option<std::path::PathBuf> {
+        let pid = self.child_pid?;
+        if !self.is_alive() {
+            return None;
+        }
+        get_process_cwd(pid)
+    }
+
     pub fn should_hide_cursor_for_streaming_output(&self) -> bool {
         // Cursor is always visible — hiding it during output caused
         // the cursor to flicker/disappear while the user was typing.
@@ -282,4 +294,30 @@ impl Drop for PtyHandle {
         self.alive.store(false, Ordering::Relaxed);
         let _ = self.killer.kill();
     }
+}
+
+/// Get the current working directory of a process by PID.
+#[cfg(target_os = "linux")]
+fn get_process_cwd(pid: u32) -> Option<std::path::PathBuf> {
+    std::fs::read_link(format!("/proc/{}/cwd", pid)).ok()
+}
+
+#[cfg(target_os = "macos")]
+fn get_process_cwd(pid: u32) -> Option<std::path::PathBuf> {
+    use std::process::Command;
+    let output = Command::new("lsof")
+        .args(["-p", &pid.to_string(), "-Fn", "-d", "cwd"])
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.lines()
+        .find(|l| l.starts_with('n'))
+        .map(|l| std::path::PathBuf::from(&l[1..]))
+}
+
+#[cfg(windows)]
+fn get_process_cwd(_pid: u32) -> Option<std::path::PathBuf> {
+    // On Windows, reading another process's CWD requires NtQueryInformationProcess.
+    // Fall back to None — the workspace CWD will be used instead.
+    None
 }


### PR DESCRIPTION
Each terminal's CWD is saved on exit and restored on startup. Shells respawn where they were, not in the default directory.