### PR TITLE
fix: sidebar interaction blocked by canvas area

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -610,7 +610,7 @@ impl eframe::App for VoidApp {
 
         egui::Area::new(egui::Id::new("canvas_content"))
             .order(egui::Order::Middle)
-            .fixed_pos(Pos2::ZERO)
+            .fixed_pos(canvas_rect.min)
             .interactable(true)
             .show(ctx, |ui| {
                 ctx.set_transform_layer(ui.layer_id(), transform);


### PR DESCRIPTION
## Summary

- The `canvas_content` Area in `app.rs` was positioned at `Pos2::ZERO` (screen coordinate origin), causing it to span the entire screen including the sidebar region
- Since this Area is rendered at `Order::Middle` (above the sidebar panel at the base layer), it intercepted pointer events — such as right-clicks — meant for sidebar items whenever terminal panels on the canvas overlapped the sidebar area
- Changed `fixed_pos(Pos2::ZERO)` to `fixed_pos(canvas_rect.min)` so the Area only covers the canvas region, allowing all sidebar interactions to work correctly

## Test plan

- [ ] Open Void with multiple terminal panels, positioning at least one so it overlaps with or is near the sidebar area
- [ ] Right-click on sidebar items (workspace entries, terminal list items) — context menus should appear
- [ ] Left-click sidebar items to switch workspaces/focus terminals — should work reliably
- [ ] Verify canvas interactions (pan, zoom, drag panels, resize panels) still work correctly
- [ ] Verify minimap overlay still renders and functions properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)