### PR TITLE
fix: workspace header always shows hover feedback in sidebar

### DIFF
--- a/src/sidebar/workspace_list.rs
+++ b/src/sidebar/workspace_list.rs
@@ -66,7 +66,7 @@ pub fn draw_workspace_tree(
             egui::Id::new("ws_header").with(ws_idx),
             egui::Sense::click(),
         );
-        if header_resp.hovered() && !is_active {
+        if header_resp.hovered() {
             let hover_rect = Rect::from_center_size(
                 header_click_rect.center(),
                 Vec2::new(header_click_rect.width(), ITEM_HEIGHT),


### PR DESCRIPTION
## Summary

Active workspace headers in the sidebar had no hover highlight, making them feel unresponsive. Users had to click another workspace first to "unstick" the interaction.

- Removed `&& !is_active` from the hover condition so the hover background always shows

## Test plan

- [ ] Hover over the active workspace header in the sidebar — highlight should appear
- [ ] Switching workspaces still works as before